### PR TITLE
Add CI workflow using GitHub Actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -51,7 +51,6 @@ jobs:
           toolchain: stable
           components: rustfmt
           override: true
-      - uses: Swatinem/rust-cache@v1
       - uses: actions-rs/cargo@v1
         with:
           command: fmt

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -57,7 +57,7 @@ jobs:
           args: --all -- --check
 
   clippy:
-    name: Clippy
+    name: Clippy Check
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,72 @@
+---
+on:
+  push:
+    branches:
+      - main
+  pull_request: {}
+
+env:
+  CARGO_TERM_COLOR: always
+
+name: Continuous integration
+
+jobs:
+  check:
+    name: Check
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - uses: Swatinem/rust-cache@v1
+      - uses: actions-rs/cargo@v1
+        with:
+          command: check
+
+  test:
+    name: Test
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - uses: Swatinem/rust-cache@v1
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test
+
+  fmt:
+    name: Format
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          components: rustfmt
+          override: true
+      - uses: Swatinem/rust-cache@v1
+      - uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all -- --check
+
+  clippy:
+    name: Clippy
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          components: clippy
+          override: true
+      - uses: Swatinem/rust-cache@v1
+      - uses: actions-rs/clippy-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          args: --all-features

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,6 +38,8 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: test
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   fmt:
     name: Format

--- a/tests/integration/resolve.rs
+++ b/tests/integration/resolve.rs
@@ -1,6 +1,6 @@
+use assert_cmd::prelude::*;
 use std::fs::read_to_string;
 use std::process::Command;
-use assert_cmd::prelude::*;
 
 const BASE_DIR: &str = "tests/integration";
 
@@ -11,10 +11,7 @@ fn process_workflow() -> anyhow::Result<()> {
     let before = format!("{}/data/before.yaml", BASE_DIR);
     let after = read_to_string(&format!("{}/data/after.yaml", BASE_DIR))?;
 
-    cmd.arg(&before)
-        .assert()
-        .success()
-        .stdout(after);
+    cmd.arg(&before).assert().success().stdout(after);
 
     Ok(())
 }


### PR DESCRIPTION
This change-set adds a basic CI workflow for Rust.

In a follow-up we'll resolve all git-refs in the `uses:` with the own utility.