### PR TITLE
Support the object type of "tag" as well as "commit"

### DIFF
--- a/src/resolve/github.rs
+++ b/src/resolve/github.rs
@@ -94,10 +94,9 @@ impl GitHub {
 
         let reference = response.first().expect("this cannot fail");
 
-        if reference.object.obj_type == "commit" {
-            return Ok(Some(reference.object.sha.clone()));
+        match reference.object.obj_type.as_str() {
+            "commit" | "tag" => return Ok(Some(reference.object.sha.clone())),
+            _ => Ok(None)
         }
-
-        Ok(None)
     }
 }

--- a/src/resolve/github.rs
+++ b/src/resolve/github.rs
@@ -96,7 +96,7 @@ impl GitHub {
 
         match reference.object.obj_type.as_str() {
             "commit" | "tag" => return Ok(Some(reference.object.sha.clone())),
-            _ => Ok(None)
+            _ => Ok(None),
         }
     }
 }


### PR DESCRIPTION
This change-set enabled the utility to both use git objects of type `tag` and `commit`.

For example:

```json
{
    "ref": "refs/tags/v1.0.7",
    "node_id": "MDM6UmVmMjA4MDYwNzcwOnJlZnMvdGFncy92MS4wLjc=",
    "url": "https://api.github.com/repos/actions-rs/toolchain/git/refs/tags/v1.0.7",
    "object": {
      "sha": "568dc894a7f9e32ffd9bb7d7a6cebb784cdaa2b0",
      "type": "tag",
      "url": "https://api.github.com/repos/actions-rs/toolchain/git/tags/568dc894a7f9e32ffd9bb7d7a6cebb784cdaa2b0"
    }
  }
```

as well as:

```json
{
    "ref": "refs/tags/1.2.0",
    "node_id": "REF_kwDOGhuu0K9yZWZzL3RhZ3MvMS4yLjA",
    "url": "https://api.github.com/repos/hendrikmaus/dummy-action/git/refs/tags/1.2.0",
    "object": {
      "sha": "d7978554106cf5f5ee9c07dc68487f771a2ebcb8",
      "type": "commit",
      "url": "https://api.github.com/repos/hendrikmaus/dummy-action/git/commits/d7978554106cf5f5ee9c07dc68487f771a2ebcb8"
    }
  }
```

Unfortunately, the GitHub API docs have nothing on the topic. Both are `refs/tags/*`, but carry different object types.