### PR TITLE
Explicitly define branch to install from

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ actions-digest --github-token <PAT> workflow.yaml
 Actions digest is written in Rust. If you have its toolchain installed, you can run this command to install:
 
 ```shell
-cargo install --git 'https://github.com/hendrikmaus/actions-digest'
+cargo install --git 'https://github.com/hendrikmaus/actions-digest' --branch main
 ```
 
 _To uninstall, use `cargo uninstall <name>`._


### PR DESCRIPTION
Seems that for some users, `cargo install --git` assumes that the remote branch has to be `master`, so it fails on repositories with `main` as their default branch.

This change-set explicitly defines the branch to use by adding `--branch` to the install-from-source command example.