### PR TITLE
Publich to cratesio on release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,56 @@
+---
+name: Release
+on:
+  release:
+    types:
+      - published
+
+env:
+  CACHE_REGISTRY: ghcr.io
+  CACHE_IMAGE: ${{ github.repository }}
+  CACHE_TAG: release-cache
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  cratesio:
+    name: crates.io
+    runs-on: ubuntu-20.04
+    steps:
+      - name: CHeckout
+        uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
+
+      - name: Setup Rust
+        uses: actions-rs/toolchain@568dc894a7f9e32ffd9bb7d7a6cebb784cdaa2b0
+        with:
+          profile: minimal
+          toolchain: stable
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          registry: ${{ env.CACHE_REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Restore cache
+        uses: hendrikmaus/custom-cache-action/restore@master
+        with:
+          registry: ${{ env.CACHE_REGISTRY }}
+          image: ${{ env.CACHE_IMAGE }}
+          tag: ${{ env.CACHE_TAG }}
+
+      - name: Publish
+        uses: katyo/publish-crates@6ca696590b94058d4fd9b7fbe4577af32a376a42
+        with:
+          registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+      - name: Save cache
+        uses: hendrikmaus/custom-cache-action/save@master
+        with:
+          paths: "${{ github.workspace }}/target /usr/share/rust/.cargo/registry/index /usr/share/rust/.cargo/registry/cache"
+          registry: ${{ env.CACHE_REGISTRY }}
+          image: ${{ env.CACHE_IMAGE }}
+          tag: ${{ env.CACHE_TAG }}

--- a/.github/workflows/release.yaml.log
+++ b/.github/workflows/release.yaml.log
@@ -1,0 +1,6 @@
+error: hendrikmaus/custom-cache-action/save@master -> GitHub API error: error decoding response body: invalid type: map, expected a sequence at line 1 column 0
+error: hendrikmaus/custom-cache-action/restore@master -> GitHub API error: error decoding response body: invalid type: map, expected a sequence at line 1 column 0
+resolved: actions/checkout@v2 -> actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
+resolved: docker/login-action@v1 -> docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+resolved: actions-rs/toolchain@v1 -> actions-rs/toolchain@568dc894a7f9e32ffd9bb7d7a6cebb784cdaa2b0
+resolved: katyo/publish-crates@v1 -> katyo/publish-crates@6ca696590b94058d4fd9b7fbe4577af32a376a42

--- a/README.md
+++ b/README.md
@@ -46,6 +46,14 @@ actions-digest --github-token <PAT> workflow.yaml
 
 Actions digest is written in Rust. If you have its toolchain installed, you can run this command to install:
 
+### Latest Release
+
+```shell
+cargo install actions-digest
+```
+
+### Latest Development Release
+
 ```shell
 cargo install --git 'https://github.com/hendrikmaus/actions-digest' --branch main
 ```


### PR DESCRIPTION
This change-set adds a release workflow to publish `actions-digest` to crates.io.

Furthermore it found a bug: https://github.com/hendrikmaus/actions-digest/issues/10