### PR TITLE
Create empty lockfile if it doesn't exist

### DIFF
--- a/src/lockfile/init.rs
+++ b/src/lockfile/init.rs
@@ -1,0 +1,24 @@
+use std::fs::File;
+use std::io::Write;
+use std::path::PathBuf;
+
+pub struct Lockfile {
+    pub path: PathBuf
+}
+
+impl Lockfile {
+    pub fn new(path: PathBuf) -> Self {
+        Self { path }
+    }
+
+    pub fn try_load_or_create(&self) -> anyhow::Result<()> {
+        if !self.path.exists() {
+            //log::debug!("lockfile at {} does not exist or is not readable", &self.path);
+            let mut file = File::create(&self.path)?;
+            file.write_all(b"")?;
+            //log::debug!("lockfile at {} written to disk", &self.path);
+        }
+
+        Ok(())
+    }
+}

--- a/src/lockfile/mod.rs
+++ b/src/lockfile/mod.rs
@@ -1,0 +1,1 @@
+pub mod init;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 mod resolve;
 mod step;
+mod lockfile;
 
 use crate::resolve::github::GitHub;
 use crate::step::Action;
@@ -44,6 +45,9 @@ static APP_USER_AGENT: &str = concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_P
 
 #[paw::main]
 fn main(args: Args) -> anyhow::Result<()> {
+    let lockfile = lockfile::init::Lockfile::new(args.lockfile);
+    lockfile.try_load_or_create()?;
+
     // While operating on such small files, it is more efficient to read and mutate them in memory.
     // One could also read the target line-by-line while writing each line, processed or not, back
     // to disk into a temporary file. But that would only make sense for very large data-sets.


### PR DESCRIPTION
If the lockfile does not yet exist on disk, or if it is not readble, try to create an empty file.